### PR TITLE
Add function to remove debug flags

### DIFF
--- a/src/add_debug_flags.c
+++ b/src/add_debug_flags.c
@@ -4,3 +4,6 @@
 void swiftnet_add_debug_flags(const uint32_t flags) {
     debugger.flags |= flags;
 }
+void swiftnet_remove_debug_flags(const uint32_t flags) {
+    debugger.flags &= ~flags;
+}

--- a/src/swift_net.h
+++ b/src/swift_net.h
@@ -398,7 +398,10 @@ extern void swiftnet_server_make_response(
 #ifdef SWIFT_NET_DEBUG
     // Adds one or more debug flags to the global debugger state.
     extern void swiftnet_add_debug_flags(const uint32_t flags);
+// Removes one or more debug flags from the global debugger state.
+    extern void swiftnet_remove_debug_flags(const uint32_t flags);
 #endif
+
 
 #ifdef __cplusplus
     }


### PR DESCRIPTION
Adds swiftnet_remove_debug_flags using bitwise operations.
Implementation follows the same pattern as swiftnet_add_debug_flags.
Function declaration was also added to the corresponding header file.

