### PR TITLE
refactor: change add/remove debug flags to use enum type

### DIFF
--- a/src/add_debug_flags.c
+++ b/src/add_debug_flags.c
@@ -1,9 +1,9 @@
-#include "swift_net.h"
 #include "internal/internal.h"
+#include "swift_net.h"
 
-void swiftnet_add_debug_flags(const uint32_t flags) {
-    debugger.flags |= flags;
+void swiftnet_add_debug_flags(const enum SwiftNetDebugFlags flags) {
+  debugger.flags |= flags;
 }
-void swiftnet_remove_debug_flags(const uint32_t flags) {
-    debugger.flags &= ~flags;
+void swiftnet_remove_debug_flags(const enum SwiftNetDebugFlags flags) {
+  debugger.flags &= ~flags;
 }

--- a/src/swift_net.h
+++ b/src/swift_net.h
@@ -2,46 +2,43 @@
 
 #include <stdint.h>
 #ifdef __cplusplus
-    extern "C" {
+extern "C" {
 
-    #define restrict __restrict__
+#define restrict __restrict__
 #endif
 
 #include <arpa/inet.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
 #include <net/ethernet.h>
-#include <pthread.h>
+#include <netinet/in.h>
 #include <netinet/ip.h>
-#include <stdbool.h>
 #include <pcap/pcap.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <sys/socket.h>
 
 #ifndef SWIFT_NET_DISABLE_ERROR_CHECKING
-    #define SWIFT_NET_ERROR
+#define SWIFT_NET_ERROR
 #endif
 
 #ifndef SWIFT_NET_DISABLE_REQUESTS
-    #define SWIFT_NET_REQUESTS
+#define SWIFT_NET_REQUESTS
 #endif
 
 #ifndef SWIFT_NET_DISABLE_DEBUGGING
-    #define SWIFT_NET_DEBUG
+#define SWIFT_NET_DEBUG
 #endif
 
-enum PacketQueueOwner {
-    NONE = 0x00,
-    SOME = 0xFF
-};
+enum PacketQueueOwner { NONE = 0x00, SOME = 0xFF };
 
 enum PacketType {
-    MESSAGE = 0x01,
-    REQUEST_INFORMATION = 0x02,
-    SEND_LOST_PACKETS_REQUEST = 0x03,
-    SEND_LOST_PACKETS_RESPONSE = 0x04,
-    SUCCESSFULLY_RECEIVED_PACKET = 0x05,
+  MESSAGE = 0x01,
+  REQUEST_INFORMATION = 0x02,
+  SEND_LOST_PACKETS_REQUEST = 0x03,
+  SEND_LOST_PACKETS_RESPONSE = 0x04,
+  SUCCESSFULLY_RECEIVED_PACKET = 0x05,
 #ifdef SWIFT_NET_REQUESTS
-    REQUEST = 0x06,
-    RESPONSE = 0x07,
+  REQUEST = 0x06,
+  RESPONSE = 0x07,
 #endif
 };
 
@@ -54,310 +51,313 @@ extern uint32_t maximum_transmission_unit;
 
 #ifdef SWIFT_NET_DEBUG
 enum SwiftNetDebugFlags {
-    PACKETS_SENDING = 1u << 0,
-    PACKETS_RECEIVING = 1u << 1,
-    INITIALIZATION = 1u << 2,
-    LOST_PACKETS = 1u << 3
+  PACKETS_SENDING = 1u << 0,
+  PACKETS_RECEIVING = 1u << 1,
+  INITIALIZATION = 1u << 2,
+  LOST_PACKETS = 1u << 3
 };
 
 struct SwiftNetDebugger {
-    uint32_t flags;
+  uint32_t flags;
 };
 #endif
 
 struct SwiftNetPortInfo {
-    uint16_t destination_port;
-    uint16_t source_port;
+  uint16_t destination_port;
+  uint16_t source_port;
 };
 
 struct SwiftNetClientAddrData {
-    struct in_addr sender_address;   
-    uint32_t maximum_transmission_unit;
-    uint16_t port;
-    uint8_t mac_address[6];
+  struct in_addr sender_address;
+  uint32_t maximum_transmission_unit;
+  uint16_t port;
+  uint8_t mac_address[6];
 };
 
 struct SwiftNetPacketClientMetadata {
-    uint32_t data_length;
-    struct SwiftNetPortInfo port_info;
-    uint16_t packet_id;
-    #ifdef SWIFT_NET_REQUESTS
-        bool expecting_response;
-    #endif
+  uint32_t data_length;
+  struct SwiftNetPortInfo port_info;
+  uint16_t packet_id;
+#ifdef SWIFT_NET_REQUESTS
+  bool expecting_response;
+#endif
 };
 
 struct SwiftNetPacketInfo {
-    uint32_t packet_length;
-    struct SwiftNetPortInfo port_info;
-    uint8_t packet_type;
-    uint32_t chunk_amount;
-    uint32_t chunk_index;
-    uint32_t maximum_transmission_unit;
+  uint32_t packet_length;
+  struct SwiftNetPortInfo port_info;
+  uint8_t packet_type;
+  uint32_t chunk_amount;
+  uint32_t chunk_index;
+  uint32_t maximum_transmission_unit;
 };
 
 struct SwiftNetPendingMessage {
-    uint8_t* packet_data_start;
-    struct SwiftNetPacketInfo packet_info;
-    uint16_t packet_id;
-    uint8_t* chunks_received;
-    uint32_t chunks_received_length;
-    uint32_t chunks_received_number;
+  uint8_t *packet_data_start;
+  struct SwiftNetPacketInfo packet_info;
+  uint16_t packet_id;
+  uint8_t *chunks_received;
+  uint32_t chunks_received_length;
+  uint32_t chunks_received_number;
 };
 
 struct SwiftNetPacketServerMetadata {
-    uint32_t data_length;
-    struct SwiftNetPortInfo port_info;
-    struct SwiftNetClientAddrData sender;
-    uint16_t packet_id;
-    #ifdef SWIFT_NET_REQUESTS
-        bool expecting_response;
-    #endif
+  uint32_t data_length;
+  struct SwiftNetPortInfo port_info;
+  struct SwiftNetClientAddrData sender;
+  uint16_t packet_id;
+#ifdef SWIFT_NET_REQUESTS
+  bool expecting_response;
+#endif
 };
 
 struct SwiftNetServerInformation {
-    uint32_t maximum_transmission_unit;
+  uint32_t maximum_transmission_unit;
 };
 
 enum PacketSendingUpdated {
-    NO_UPDATE,
-    UPDATED_LOST_CHUNKS,
-    SUCCESSFULLY_RECEIVED
+  NO_UPDATE,
+  UPDATED_LOST_CHUNKS,
+  SUCCESSFULLY_RECEIVED
 };
 
 struct SwiftNetPacketSending {
-    uint16_t packet_id;
-    uint32_t* lost_chunks;
-    uint32_t lost_chunks_size;
-    _Atomic enum PacketSendingUpdated updated;
-    _Atomic bool locked;
+  uint16_t packet_id;
+  uint32_t *lost_chunks;
+  uint32_t lost_chunks_size;
+  _Atomic enum PacketSendingUpdated updated;
+  _Atomic bool locked;
 };
 
 struct SwiftNetPacketCompleted {
-    uint16_t packet_id;
+  uint16_t packet_id;
 };
 
 struct SwiftNetPacketBuffer {
-    uint8_t* packet_buffer_start;   // Start of the allocated buffer
-    uint8_t* packet_data_start;     // Start of the stored data
-    uint8_t* packet_append_pointer; // Current position to append new data
+  uint8_t *packet_buffer_start;   // Start of the allocated buffer
+  uint8_t *packet_data_start;     // Start of the stored data
+  uint8_t *packet_append_pointer; // Current position to append new data
 };
 
 struct PacketQueueNode {
-    struct PacketQueueNode* next;
-    uint8_t* data;
-    uint32_t data_read;
-    struct in_addr sender_address;   
+  struct PacketQueueNode *next;
+  uint8_t *data;
+  uint32_t data_read;
+  struct in_addr sender_address;
 };
 
 struct PacketQueue {
-    _Atomic enum PacketQueueOwner owner;
-    struct PacketQueueNode* first_node;
-    struct PacketQueueNode* last_node;
+  _Atomic enum PacketQueueOwner owner;
+  struct PacketQueueNode *first_node;
+  struct PacketQueueNode *last_node;
 };
 
 struct PacketCallbackQueueNode {
-    void* packet_data;
-    struct SwiftNetPendingMessage* pending_message;
-    uint16_t packet_id;
-    struct PacketCallbackQueueNode* next;
+  void *packet_data;
+  struct SwiftNetPendingMessage *pending_message;
+  uint16_t packet_id;
+  struct PacketCallbackQueueNode *next;
 };
 
 struct SwiftNetServerPacketData {
-    uint8_t* data;
-    uint8_t* current_pointer;
-    struct SwiftNetPacketServerMetadata metadata;
-    struct SwiftNetPendingMessage* internal_pending_message; // Do not use!!
+  uint8_t *data;
+  uint8_t *current_pointer;
+  struct SwiftNetPacketServerMetadata metadata;
+  struct SwiftNetPendingMessage *internal_pending_message; // Do not use!!
 };
 
 struct SwiftNetClientPacketData {
-    uint8_t* data;
-    uint8_t* current_pointer;
-    struct SwiftNetPacketClientMetadata metadata;
-    struct SwiftNetPendingMessage* internal_pending_message; // Do not use!!
+  uint8_t *data;
+  uint8_t *current_pointer;
+  struct SwiftNetPacketClientMetadata metadata;
+  struct SwiftNetPendingMessage *internal_pending_message; // Do not use!!
 };
 
 struct PacketCallbackQueue {
-    _Atomic enum PacketQueueOwner owner;
-    struct PacketCallbackQueueNode* first_node;
-    struct PacketCallbackQueueNode* last_node;
+  _Atomic enum PacketQueueOwner owner;
+  struct PacketCallbackQueueNode *first_node;
+  struct PacketCallbackQueueNode *last_node;
 };
 
 struct SwiftNetSentSuccessfullyCompletedPacketSignal {
-    uint16_t packet_id;
-    bool confirmed;
+  uint16_t packet_id;
+  bool confirmed;
 };
 
 struct SwiftNetMemoryAllocatorStack {
-    _Atomic uint32_t size;
-    void* pointers;
-    void* data;
-    _Atomic(void*) next;
-    _Atomic(void*) previous;
-    _Atomic uint8_t owner;
-    #ifdef SWIFT_NET_INTERNAL_TESTING 
-    uint8_t* ptr_status;
-    _Atomic bool accessing_ptr_status;
-    #endif
+  _Atomic uint32_t size;
+  void *pointers;
+  void *data;
+  _Atomic(void *) next;
+  _Atomic(void *) previous;
+  _Atomic uint8_t owner;
+#ifdef SWIFT_NET_INTERNAL_TESTING
+  uint8_t *ptr_status;
+  _Atomic bool accessing_ptr_status;
+#endif
 };
 
 struct SwiftNetChunkStorageManager {
-    _Atomic(void*) first_item;
-    _Atomic(void*) last_item;
+  _Atomic(void *) first_item;
+  _Atomic(void *) last_item;
 };
 
 struct SwiftNetMemoryAllocator {
-    struct SwiftNetChunkStorageManager data;
-    uint32_t item_size;
-    uint32_t chunk_item_amount;
-    _Atomic uint8_t creating_stack;
+  struct SwiftNetChunkStorageManager data;
+  uint32_t item_size;
+  uint32_t chunk_item_amount;
+  _Atomic uint8_t creating_stack;
 };
 
 struct SwiftNetVector {
-    void* data;
-    uint32_t size;
-    uint32_t capacity;
-    _Atomic uint8_t locked;
+  void *data;
+  uint32_t size;
+  uint32_t capacity;
+  _Atomic uint8_t locked;
 };
 
 // Connection data
 struct SwiftNetClientConnection {
-    pcap_t* pcap;
-    struct ether_header eth_header;
-    struct SwiftNetPortInfo port_info;
-    struct in_addr server_addr;
-    _Atomic(void (*)(struct SwiftNetClientPacketData* const, void* const user)) packet_handler;
-    _Atomic(void*) packet_handler_user_arg;
-    _Atomic bool closing;
-    _Atomic bool initialized;
-    uint16_t addr_type;
-    bool loopback;
-    pthread_t process_packets_thread;
-    pthread_t execute_callback_thread;
-    uint32_t maximum_transmission_unit;
-    struct SwiftNetVector pending_messages;
-    struct SwiftNetMemoryAllocator pending_messages_memory_allocator;
-    struct SwiftNetVector packets_sending;
-    struct SwiftNetMemoryAllocator packets_sending_memory_allocator;
-    struct SwiftNetVector packets_completed;
-    struct SwiftNetMemoryAllocator packets_completed_memory_allocator;
-    struct PacketQueue packet_queue;
-    struct PacketCallbackQueue packet_callback_queue;
-    uint8_t prepend_size;
+  pcap_t *pcap;
+  struct ether_header eth_header;
+  struct SwiftNetPortInfo port_info;
+  struct in_addr server_addr;
+  _Atomic(void (*)(struct SwiftNetClientPacketData *const,
+                   void *const user)) packet_handler;
+  _Atomic(void *) packet_handler_user_arg;
+  _Atomic bool closing;
+  _Atomic bool initialized;
+  uint16_t addr_type;
+  bool loopback;
+  pthread_t process_packets_thread;
+  pthread_t execute_callback_thread;
+  uint32_t maximum_transmission_unit;
+  struct SwiftNetVector pending_messages;
+  struct SwiftNetMemoryAllocator pending_messages_memory_allocator;
+  struct SwiftNetVector packets_sending;
+  struct SwiftNetMemoryAllocator packets_sending_memory_allocator;
+  struct SwiftNetVector packets_completed;
+  struct SwiftNetMemoryAllocator packets_completed_memory_allocator;
+  struct PacketQueue packet_queue;
+  struct PacketCallbackQueue packet_callback_queue;
+  uint8_t prepend_size;
 };
 
 struct SwiftNetServer {
-    pcap_t* pcap;
-    struct ether_header eth_header;
-    uint16_t server_port;
-    _Atomic(void (*)(struct SwiftNetServerPacketData* const, void* const user)) packet_handler;
-    _Atomic(void*) packet_handler_user_arg;
-    _Atomic bool closing;
-    uint16_t addr_type;
-    bool loopback;
-    pthread_t process_packets_thread;
-    pthread_t execute_callback_thread;
-    struct SwiftNetVector pending_messages;
-    struct SwiftNetMemoryAllocator pending_messages_memory_allocator;
-    struct SwiftNetVector packets_sending;
-    struct SwiftNetMemoryAllocator packets_sending_memory_allocator;
-    struct SwiftNetVector packets_completed;
-    struct SwiftNetMemoryAllocator packets_completed_memory_allocator;
-    uint8_t* current_read_pointer;
-    struct PacketQueue packet_queue;
-    struct PacketCallbackQueue packet_callback_queue;
-    uint8_t prepend_size;
+  pcap_t *pcap;
+  struct ether_header eth_header;
+  uint16_t server_port;
+  _Atomic(void (*)(struct SwiftNetServerPacketData *const,
+                   void *const user)) packet_handler;
+  _Atomic(void *) packet_handler_user_arg;
+  _Atomic bool closing;
+  uint16_t addr_type;
+  bool loopback;
+  pthread_t process_packets_thread;
+  pthread_t execute_callback_thread;
+  struct SwiftNetVector pending_messages;
+  struct SwiftNetMemoryAllocator pending_messages_memory_allocator;
+  struct SwiftNetVector packets_sending;
+  struct SwiftNetMemoryAllocator packets_sending_memory_allocator;
+  struct SwiftNetVector packets_completed;
+  struct SwiftNetMemoryAllocator packets_completed_memory_allocator;
+  uint8_t *current_read_pointer;
+  struct PacketQueue packet_queue;
+  struct PacketCallbackQueue packet_callback_queue;
+  uint8_t prepend_size;
 };
 
 // Set a custom message (packet) handler for the server.
 extern void swiftnet_server_set_message_handler(
-    struct SwiftNetServer* const server,
-    void (* const new_handler)(struct SwiftNetServerPacketData* const, void* const),
-    void* const user_arg
-);
+    struct SwiftNetServer *const server,
+    void (*const new_handler)(struct SwiftNetServerPacketData *const,
+                              void *const),
+    void *const user_arg);
 
 // Set a custom message (packet) handler for the client.
 extern void swiftnet_client_set_message_handler(
-    struct SwiftNetClientConnection* const client,
-    void (* const new_handler)(struct SwiftNetClientPacketData* const, void* const),
-    void* const user_arg
-);
+    struct SwiftNetClientConnection *const client,
+    void (*const new_handler)(struct SwiftNetClientPacketData *const,
+                              void *const),
+    void *const user_arg);
 
 // Append data to a packet buffer.
-extern void swiftnet_client_append_to_packet(
-    const void* const data,
-    const uint32_t data_size,
-    struct SwiftNetPacketBuffer* const packet
-);
-
+extern void
+swiftnet_client_append_to_packet(const void *const data,
+                                 const uint32_t data_size,
+                                 struct SwiftNetPacketBuffer *const packet);
 
 // Append data to a packet buffer.
-extern void swiftnet_server_append_to_packet(
-    const void* const data,
-    const uint32_t data_size,
-    struct SwiftNetPacketBuffer* const packet
-);
+extern void
+swiftnet_server_append_to_packet(const void *const data,
+                                 const uint32_t data_size,
+                                 struct SwiftNetPacketBuffer *const packet);
 
 // Clean up and free resources for a client connection.
-extern void swiftnet_client_cleanup(struct SwiftNetClientConnection* const client);
+extern void
+swiftnet_client_cleanup(struct SwiftNetClientConnection *const client);
 
 // Clean up and free resources for a server.
-extern void swiftnet_server_cleanup(struct SwiftNetServer* const server);
+extern void swiftnet_server_cleanup(struct SwiftNetServer *const server);
 
 // Initialize the SwiftNet library.
 extern void swiftnet_initialize();
 
 // Send a packet from the client to its connected server.
-extern void swiftnet_client_send_packet(
-    struct SwiftNetClientConnection* const client,
-    struct SwiftNetPacketBuffer* const packet
-);
+extern void
+swiftnet_client_send_packet(struct SwiftNetClientConnection *const client,
+                            struct SwiftNetPacketBuffer *const packet);
 
 // Send a packet from the server to a specified client.
-extern void swiftnet_server_send_packet(
-    struct SwiftNetServer* const server,
-    struct SwiftNetPacketBuffer* const packet,
-    const struct SwiftNetClientAddrData target
-);
+extern void
+swiftnet_server_send_packet(struct SwiftNetServer *const server,
+                            struct SwiftNetPacketBuffer *const packet,
+                            const struct SwiftNetClientAddrData target);
 
 // Create a packet buffer for the server.
-extern struct SwiftNetPacketBuffer swiftnet_server_create_packet_buffer(const uint32_t buffer_size);
+extern struct SwiftNetPacketBuffer
+swiftnet_server_create_packet_buffer(const uint32_t buffer_size);
 
 // Create a packet buffer for the client.
-extern struct SwiftNetPacketBuffer swiftnet_client_create_packet_buffer(const uint32_t buffer_size);
+extern struct SwiftNetPacketBuffer
+swiftnet_client_create_packet_buffer(const uint32_t buffer_size);
 
 // Destroy a server packet buffer and free resources.
-extern void swiftnet_server_destroy_packet_buffer(const struct SwiftNetPacketBuffer* const packet);
+extern void swiftnet_server_destroy_packet_buffer(
+    const struct SwiftNetPacketBuffer *const packet);
 
 // Destroy a client packet buffer and free resources.
-extern void swiftnet_client_destroy_packet_buffer(const struct SwiftNetPacketBuffer* const packet);
+extern void swiftnet_client_destroy_packet_buffer(
+    const struct SwiftNetPacketBuffer *const packet);
 
 // Create and initialize a server.
-extern struct SwiftNetServer* swiftnet_create_server(const uint16_t port, const bool loopback);
+extern struct SwiftNetServer *swiftnet_create_server(const uint16_t port,
+                                                     const bool loopback);
 
 // Create and initialize a client connection.
-extern struct SwiftNetClientConnection* swiftnet_create_client(
-    const char* const ip_address,
-    const uint16_t port,
-    const uint32_t timeout_ms
-);
+extern struct SwiftNetClientConnection *
+swiftnet_create_client(const char *const ip_address, const uint16_t port,
+                       const uint32_t timeout_ms);
 
 // Read data from a client packet.
-extern void* swiftnet_client_read_packet(struct SwiftNetClientPacketData* const packet_data, const uint32_t data_size);
+extern void *
+swiftnet_client_read_packet(struct SwiftNetClientPacketData *const packet_data,
+                            const uint32_t data_size);
 
 // Read data from a server packet.
-extern void* swiftnet_server_read_packet(struct SwiftNetServerPacketData* const packet_data, const uint32_t data_size);
+extern void *
+swiftnet_server_read_packet(struct SwiftNetServerPacketData *const packet_data,
+                            const uint32_t data_size);
 
 // Destroy client packet data and release memory.
 extern void swiftnet_client_destroy_packet_data(
-    struct SwiftNetClientPacketData* const packet_data,
-    struct SwiftNetClientConnection* const client_conn
-);
+    struct SwiftNetClientPacketData *const packet_data,
+    struct SwiftNetClientConnection *const client_conn);
 
 // Destroy server packet data and release memory.
 extern void swiftnet_server_destroy_packet_data(
-    struct SwiftNetServerPacketData* const packet_data,
-    struct SwiftNetServer* const server
-);
+    struct SwiftNetServerPacketData *const packet_data,
+    struct SwiftNetServer *const server);
 
 // Clean up the entire SwiftNet library.
 extern void swiftnet_cleanup();
@@ -365,43 +365,38 @@ extern void swiftnet_cleanup();
 #ifdef SWIFT_NET_REQUESTS
 
 // Make a request from a client and wait for a response.
-extern struct SwiftNetClientPacketData* swiftnet_client_make_request(
-    struct SwiftNetClientConnection* const client,
-    struct SwiftNetPacketBuffer* const packet,
-    const uint32_t timeout_ms
-);
+extern struct SwiftNetClientPacketData *
+swiftnet_client_make_request(struct SwiftNetClientConnection *const client,
+                             struct SwiftNetPacketBuffer *const packet,
+                             const uint32_t timeout_ms);
 
 // Make a request from the server to a specific client and wait for response.
-extern struct SwiftNetServerPacketData* swiftnet_server_make_request(
-    struct SwiftNetServer* const server,
-    struct SwiftNetPacketBuffer* const packet,
-    const struct SwiftNetClientAddrData addr_data,
-    const uint32_t timeout_ms
-);
+extern struct SwiftNetServerPacketData *
+swiftnet_server_make_request(struct SwiftNetServer *const server,
+                             struct SwiftNetPacketBuffer *const packet,
+                             const struct SwiftNetClientAddrData addr_data,
+                             const uint32_t timeout_ms);
 
 // Send a response from a client.
 extern void swiftnet_client_make_response(
-    struct SwiftNetClientConnection* const client,
-    struct SwiftNetClientPacketData* const packet_data,
-    struct SwiftNetPacketBuffer* const buffer
-);
+    struct SwiftNetClientConnection *const client,
+    struct SwiftNetClientPacketData *const packet_data,
+    struct SwiftNetPacketBuffer *const buffer);
 
 // Send a response from the server.
 extern void swiftnet_server_make_response(
-    struct SwiftNetServer* const server,
-    struct SwiftNetServerPacketData* const packet_data,
-    struct SwiftNetPacketBuffer* const buffer
-);
+    struct SwiftNetServer *const server,
+    struct SwiftNetServerPacketData *const packet_data,
+    struct SwiftNetPacketBuffer *const buffer);
 #endif
 
 #ifdef SWIFT_NET_DEBUG
-    // Adds one or more debug flags to the global debugger state.
-    extern void swiftnet_add_debug_flags(const uint32_t flags);
-    // Removes one or more debug flags from the global debugger state.
-    extern void swiftnet_remove_debug_flags(const uint32_t flags);
+// Adds one or more debug flags to the global debugger state.
+extern void swiftnet_add_debug_flags(const enum SwiftNetDebugFlags flags);
+// Removes one or more debug flags from the global debugger state.
+extern void swiftnet_remove_debug_flags(const enum SwiftNetDebugFlags flags);
 #endif
 
-
 #ifdef __cplusplus
-    }
+}
 #endif

--- a/tests/integration_tests/src/run_tests.c
+++ b/tests/integration_tests/src/run_tests.c
@@ -1,242 +1,178 @@
 #include "run_tests.h"
 #include "../../../src/swift_net.h"
-#include <stdint.h>
-#include <stdio.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <ifaddrs.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
 #include "../../shared.h"
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <netinet/in.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 char private_ip_address_testing[INET_ADDRSTRLEN];
 
 int main() {
-    get_private_ip_from_socket();
+  get_private_ip_from_socket();
 
-    const struct Test tests[] = {
-        // Loopback tests
-        {
-            .function = test_sending_packet,
-            .args = {.test_sending_packet_args = {
-                .client_data_len = 50,
-                .server_data_len = 50,
-                .ip_address = "127.0.0.1",
-                .loopback = true
-            }},
-            .test_name = "Test sending small packets"
-        },
-        {
-            .function = test_sending_packet,
-            .args = {.test_sending_packet_args = {
-                .client_data_len = 0,
-                .server_data_len = 10000,
-                .ip_address = "127.0.0.1",
-                .loopback = true
-            }},
-            .test_name = "Test client sending large packet"
-        },
-        {
-            .function = test_sending_packet,
-            .args = {.test_sending_packet_args = {
-                .client_data_len = 10000,
-                .server_data_len = 10,
-                .ip_address = "127.0.0.1",
-                .loopback = true
-            }},
-            .test_name = "Test server sending large packet"
-        },
-        {
-            .function = test_making_request,
-            .args = {.test_making_request_args = {
-                .ip_address = "127.0.0.1",
-                .loopback = true,
-                .receiver = Server,
-                .request_data_len = 100,
-                .response_data_len = 100
-            }},
-            .test_name = "Test client making small request"
-        },
-        {
-            .function = test_making_request,
-            .args = {.test_making_request_args = {
-                .ip_address = "127.0.0.1",
-                .loopback = true,
-                .receiver = Client,
-                .request_data_len = 100,
-                .response_data_len = 100
-            }},
-            .test_name = "Test server making small request"
-        },
-        {
-            .function = test_making_request,
-            .args = {.test_making_request_args = {
-                .ip_address = "127.0.0.1",
-                .loopback = true,
-                .receiver = Client,
-                .request_data_len = 10000,
-                .response_data_len = 100
-            }},
-            .test_name = "Test server making large request"
-        },
-        {
-            .function = test_making_request,
-            .args = {.test_making_request_args = {
-                .ip_address = "127.0.0.1",
-                .loopback = true,
-                .receiver = Server,
-                .request_data_len = 10000,
-                .response_data_len = 100
-            }},
-            .test_name = "Test client making large request"
-        },
-        {
-            .function = test_making_request,
-            .args = {.test_making_request_args = {
-                .ip_address = "127.0.0.1",
-                .loopback = true,
-                .receiver = Client,
-                .request_data_len = 100,
-                .response_data_len = 10000
-            }},
-            .test_name = "Test client making large response"
-        },
-        {
-            .function = test_making_request,
-            .args = {.test_making_request_args = {
-                .ip_address = "127.0.0.1",
-                .loopback = true,
-                .receiver = Server,
-                .request_data_len = 100,
-                .response_data_len = 10000
-            }},
-            .test_name = "Test server making large response"
-        },
-        // local default interface test
-        {
-            .function = test_sending_packet,
-            .args = {.test_sending_packet_args = {
-                .client_data_len = 50,
-                .server_data_len = 50,
-                .ip_address = private_ip_address_testing,
-                .loopback = false
-            }},
-            .test_name = "Test sending small packets"
-        },
-        {
-            .function = test_sending_packet,
-            .args = {.test_sending_packet_args = {
-                .client_data_len = 0,
-                .server_data_len = 10000,
-                .ip_address = private_ip_address_testing,
-                .loopback = false
-            }},
-            .test_name = "Test client sending large packet"
-        },
-        {
-            .function = test_sending_packet,
-            .args = {.test_sending_packet_args = {
-                .client_data_len = 10000,
-                .server_data_len = 10,
-                .ip_address = private_ip_address_testing,
-                .loopback = false
-            }},
-            .test_name = "Test server sending large packet"
-        },
-        {
-            .function = test_making_request,
-            .args = {.test_making_request_args = {
-                .ip_address = private_ip_address_testing,
-                .loopback = false,
-                .receiver = Server,
-                .request_data_len = 100,
-                .response_data_len = 100
-            }},
-            .test_name = "Test client making small request"
-        },
-        {
-            .function = test_making_request,
-            .args = {.test_making_request_args = {
-                .ip_address = private_ip_address_testing,
-                .loopback = false,
-                .receiver = Client,
-                .request_data_len = 100,
-                .response_data_len = 100
-            }},
-            .test_name = "Test server making small request"
-        },
-        {
-            .function = test_making_request,
-            .args = {.test_making_request_args = {
-                .ip_address = private_ip_address_testing,
-                .loopback = false,
-                .receiver = Client,
-                .request_data_len = 10000,
-                .response_data_len = 100
-            }},
-            .test_name = "Test server making large request"
-        },
-        {
-            .function = test_making_request,
-            .args = {.test_making_request_args = {
-                .ip_address = private_ip_address_testing,
-                .loopback = false,
-                .receiver = Server,
-                .request_data_len = 10000,
-                .response_data_len = 100
-            }},
-            .test_name = "Test client making large request"
-        },
-        {
-            .function = test_making_request,
-            .args = {.test_making_request_args = {
-                .ip_address = private_ip_address_testing,
-                .loopback = false,
-                .receiver = Client,
-                .request_data_len = 100,
-                .response_data_len = 10000
-            }},
-            .test_name = "Test client making large response"
-        },
-        {
-            .function = test_making_request,
-            .args = {.test_making_request_args = {
-                .ip_address = private_ip_address_testing,
-                .loopback = false,
-                .receiver = Server,
-                .request_data_len = 100,
-                .response_data_len = 10000
-            }},
-            .test_name = "Test server making large response"
-        },
-    };
+  const struct Test tests[] = {
+      // Loopback tests
+      {.function = test_sending_packet,
+       .args = {.test_sending_packet_args = {.client_data_len = 50,
+                                             .server_data_len = 50,
+                                             .ip_address = "127.0.0.1",
+                                             .loopback = true}},
+       .test_name = "Test sending small packets"},
+      {.function = test_sending_packet,
+       .args = {.test_sending_packet_args = {.client_data_len = 0,
+                                             .server_data_len = 10000,
+                                             .ip_address = "127.0.0.1",
+                                             .loopback = true}},
+       .test_name = "Test client sending large packet"},
+      {.function = test_sending_packet,
+       .args = {.test_sending_packet_args = {.client_data_len = 10000,
+                                             .server_data_len = 10,
+                                             .ip_address = "127.0.0.1",
+                                             .loopback = true}},
+       .test_name = "Test server sending large packet"},
+      {.function = test_making_request,
+       .args = {.test_making_request_args = {.ip_address = "127.0.0.1",
+                                             .loopback = true,
+                                             .receiver = Server,
+                                             .request_data_len = 100,
+                                             .response_data_len = 100}},
+       .test_name = "Test client making small request"},
+      {.function = test_making_request,
+       .args = {.test_making_request_args = {.ip_address = "127.0.0.1",
+                                             .loopback = true,
+                                             .receiver = Client,
+                                             .request_data_len = 100,
+                                             .response_data_len = 100}},
+       .test_name = "Test server making small request"},
+      {.function = test_making_request,
+       .args = {.test_making_request_args = {.ip_address = "127.0.0.1",
+                                             .loopback = true,
+                                             .receiver = Client,
+                                             .request_data_len = 10000,
+                                             .response_data_len = 100}},
+       .test_name = "Test server making large request"},
+      {.function = test_making_request,
+       .args = {.test_making_request_args = {.ip_address = "127.0.0.1",
+                                             .loopback = true,
+                                             .receiver = Server,
+                                             .request_data_len = 10000,
+                                             .response_data_len = 100}},
+       .test_name = "Test client making large request"},
+      {.function = test_making_request,
+       .args = {.test_making_request_args = {.ip_address = "127.0.0.1",
+                                             .loopback = true,
+                                             .receiver = Client,
+                                             .request_data_len = 100,
+                                             .response_data_len = 10000}},
+       .test_name = "Test client making large response"},
+      {.function = test_making_request,
+       .args = {.test_making_request_args = {.ip_address = "127.0.0.1",
+                                             .loopback = true,
+                                             .receiver = Server,
+                                             .request_data_len = 100,
+                                             .response_data_len = 10000}},
+       .test_name = "Test server making large response"},
+      // local default interface test
+      {.function = test_sending_packet,
+       .args = {.test_sending_packet_args = {.client_data_len = 50,
+                                             .server_data_len = 50,
+                                             .ip_address =
+                                                 private_ip_address_testing,
+                                             .loopback = false}},
+       .test_name = "Test sending small packets"},
+      {.function = test_sending_packet,
+       .args = {.test_sending_packet_args = {.client_data_len = 0,
+                                             .server_data_len = 10000,
+                                             .ip_address =
+                                                 private_ip_address_testing,
+                                             .loopback = false}},
+       .test_name = "Test client sending large packet"},
+      {.function = test_sending_packet,
+       .args = {.test_sending_packet_args = {.client_data_len = 10000,
+                                             .server_data_len = 10,
+                                             .ip_address =
+                                                 private_ip_address_testing,
+                                             .loopback = false}},
+       .test_name = "Test server sending large packet"},
+      {.function = test_making_request,
+       .args = {.test_making_request_args = {.ip_address =
+                                                 private_ip_address_testing,
+                                             .loopback = false,
+                                             .receiver = Server,
+                                             .request_data_len = 100,
+                                             .response_data_len = 100}},
+       .test_name = "Test client making small request"},
+      {.function = test_making_request,
+       .args = {.test_making_request_args = {.ip_address =
+                                                 private_ip_address_testing,
+                                             .loopback = false,
+                                             .receiver = Client,
+                                             .request_data_len = 100,
+                                             .response_data_len = 100}},
+       .test_name = "Test server making small request"},
+      {.function = test_making_request,
+       .args = {.test_making_request_args = {.ip_address =
+                                                 private_ip_address_testing,
+                                             .loopback = false,
+                                             .receiver = Client,
+                                             .request_data_len = 10000,
+                                             .response_data_len = 100}},
+       .test_name = "Test server making large request"},
+      {.function = test_making_request,
+       .args = {.test_making_request_args = {.ip_address =
+                                                 private_ip_address_testing,
+                                             .loopback = false,
+                                             .receiver = Server,
+                                             .request_data_len = 10000,
+                                             .response_data_len = 100}},
+       .test_name = "Test client making large request"},
+      {.function = test_making_request,
+       .args = {.test_making_request_args = {.ip_address =
+                                                 private_ip_address_testing,
+                                             .loopback = false,
+                                             .receiver = Client,
+                                             .request_data_len = 100,
+                                             .response_data_len = 10000}},
+       .test_name = "Test client making large response"},
+      {.function = test_making_request,
+       .args = {.test_making_request_args = {.ip_address =
+                                                 private_ip_address_testing,
+                                             .loopback = false,
+                                             .receiver = Server,
+                                             .request_data_len = 100,
+                                             .response_data_len = 10000}},
+       .test_name = "Test server making large response"},
+  };
 
-    swiftnet_initialize();
+  swiftnet_initialize();
 
-    swiftnet_add_debug_flags(INITIALIZATION | LOST_PACKETS | PACKETS_RECEIVING | PACKETS_SENDING);
+  swiftnet_add_debug_flags((enum SwiftNetDebugFlags)(
+      INITIALIZATION | LOST_PACKETS | PACKETS_RECEIVING | PACKETS_SENDING));
 
-    for (uint16_t i = 0; i < sizeof(tests) / sizeof(struct Test); i++) {
-        const struct Test* current_test = &tests[i];
+  for (uint16_t i = 0; i < sizeof(tests) / sizeof(struct Test); i++) {
+    const struct Test *current_test = &tests[i];
 
-        int result = current_test->function(&current_test->args);
-        if (result != 0) {
-            PRINT_ERROR("Failed test: %s", current_test->test_name);
+    int result = current_test->function(&current_test->args);
+    if (result != 0) {
+      PRINT_ERROR("Failed test: %s", current_test->test_name);
 
-            swiftnet_cleanup();
+      swiftnet_cleanup();
 
-            return -1;
-        }
-
-        PRINT_SUCCESS("Successfully completed test: %s", current_test->test_name);
-
-        continue;
+      return -1;
     }
 
-    swiftnet_cleanup();
+    PRINT_SUCCESS("Successfully completed test: %s", current_test->test_name);
 
-    return 0;
+    continue;
+  }
+
+  swiftnet_cleanup();
+
+  return 0;
 }

--- a/tests/performance_tests/src/main.c
+++ b/tests/performance_tests/src/main.c
@@ -1,15 +1,14 @@
+#include "../../../src/swift_net.h"
+#include "../../shared.h"
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "../../../src/swift_net.h"
-#include "../../shared.h"
-
 
 #define PACKET_SIZE 1000000 // 1 MILLION BYTES
-#define PACKETS_TO_SEND 50 // HOW MANY PACKETS TO SEND
+#define PACKETS_TO_SEND 50  // HOW MANY PACKETS TO SEND
 
 // ********************** //
 // SEND 50 MILLION BYTES //
@@ -22,75 +21,83 @@ static struct timespec start, end;
 static uint32_t packets_received = 0;
 static _Atomic bool finished = false;
 
-void packet_callback(struct SwiftNetServerPacketData* const packet_data, void* server) {
-    packets_received++;
+void packet_callback(struct SwiftNetServerPacketData *const packet_data,
+                     void *server) {
+  packets_received++;
 
-    if (packets_received == PACKETS_TO_SEND) {
-        atomic_store_explicit(&finished, true, memory_order_release);
-    }
+  if (packets_received == PACKETS_TO_SEND) {
+    atomic_store_explicit(&finished, true, memory_order_release);
+  }
 
-    swiftnet_server_destroy_packet_data(packet_data, server);
+  swiftnet_server_destroy_packet_data(packet_data, server);
 }
 
 void send_large_packets(const bool loopback) {
-    struct SwiftNetServer* const server = swiftnet_create_server(8080, loopback);
-    if (server == NULL) {
-        PRINT_ERROR("FAILED TO INIT SERVER");
-        swiftnet_cleanup();
-        exit(EXIT_FAILURE);
-    }
-    
-    swiftnet_server_set_message_handler(server, packet_callback, server);
+  struct SwiftNetServer *const server = swiftnet_create_server(8080, loopback);
+  if (server == NULL) {
+    PRINT_ERROR("FAILED TO INIT SERVER");
+    swiftnet_cleanup();
+    exit(EXIT_FAILURE);
+  }
 
-    struct SwiftNetClientConnection* const client = swiftnet_create_client(loopback ? "127.0.0.1" : private_ip_address_testing, 8080, 1000);
-    if (client == NULL) {
-        PRINT_ERROR("FAILED TO INIT CLIENT");
-        swiftnet_server_cleanup(server);
-        swiftnet_cleanup();
-        exit(EXIT_FAILURE);
-    }
+  swiftnet_server_set_message_handler(server, packet_callback, server);
 
-    struct SwiftNetPacketBuffer buffer = swiftnet_client_create_packet_buffer(PACKET_SIZE);
+  struct SwiftNetClientConnection *const client = swiftnet_create_client(
+      loopback ? "127.0.0.1" : private_ip_address_testing, 8080, 1000);
+  if (client == NULL) {
+    PRINT_ERROR("FAILED TO INIT CLIENT");
+    swiftnet_server_cleanup(server);
+    swiftnet_cleanup();
+    exit(EXIT_FAILURE);
+  }
 
-    uint8_t* const random_data = malloc(PACKET_SIZE);
-    for (uint32_t i = 0; i < PACKET_SIZE; i++) {
-        random_data[i] = rand();
-    }
+  struct SwiftNetPacketBuffer buffer =
+      swiftnet_client_create_packet_buffer(PACKET_SIZE);
 
-    swiftnet_client_append_to_packet(random_data, PACKET_SIZE, &buffer);
+  uint8_t *const random_data = malloc(PACKET_SIZE);
+  for (uint32_t i = 0; i < PACKET_SIZE; i++) {
+    random_data[i] = rand();
+  }
 
-    clock_gettime(CLOCK_MONOTONIC, &start);;
+  swiftnet_client_append_to_packet(random_data, PACKET_SIZE, &buffer);
 
-    for (uint32_t i = 0; i < PACKETS_TO_SEND; i++) {
-        swiftnet_client_send_packet(client, &buffer);
-    }
+  clock_gettime(CLOCK_MONOTONIC, &start);
+  ;
 
-    while (atomic_load_explicit(&finished, memory_order_acquire) == false) {
-        continue;
-    }
+  for (uint32_t i = 0; i < PACKETS_TO_SEND; i++) {
+    swiftnet_client_send_packet(client, &buffer);
+  }
 
-    swiftnet_client_destroy_packet_buffer(&buffer);
+  while (atomic_load_explicit(&finished, memory_order_acquire) == false) {
+    continue;
+  }
 
-    clock_gettime(CLOCK_MONOTONIC, &end);;
+  swiftnet_client_destroy_packet_buffer(&buffer);
 
-    usleep(100000);
+  clock_gettime(CLOCK_MONOTONIC, &end);
+  ;
 
-    double elapsed = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1e9;
+  usleep(100000);
 
-    PRINT_SUCCESS("Time to send: %.2f seconds", elapsed);
-    PRINT_SUCCESS("Bytes per second: %.2f", (PACKETS_TO_SEND * PACKET_SIZE) / elapsed)
+  double elapsed =
+      (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1e9;
 
-    swiftnet_client_cleanup(client);
+  PRINT_SUCCESS("Time to send: %.2f seconds", elapsed);
+  PRINT_SUCCESS("Bytes per second: %.2f",
+                (PACKETS_TO_SEND * PACKET_SIZE) / elapsed)
+
+  swiftnet_client_cleanup(client);
 }
 
 int main() {
-    swiftnet_initialize();
+  swiftnet_initialize();
 
-    swiftnet_add_debug_flags(PACKETS_SENDING | PACKETS_RECEIVING | INITIALIZATION | LOST_PACKETS);
+  swiftnet_add_debug_flags((enum SwiftNetDebugFlags)(
+      PACKETS_SENDING | PACKETS_RECEIVING | INITIALIZATION | LOST_PACKETS));
 
-    send_large_packets(false);
+  send_large_packets(false);
 
-    swiftnet_cleanup();
+  swiftnet_cleanup();
 
-    return 0;
+  return 0;
 }


### PR DESCRIPTION
Updated debug flag signatures to use the SwiftNetDebugFlags enum instead of a raw uint32_t.

- Updated swift_net.h and add_debug_flags.c signatures.

- Added necessary casts in the integration and perf tests to keep the compiler happy when ORing flags.

Testing: Built via ./build/build_for_testing.sh and ran integration tests under sudo. Everything passed with no leaks.

Fixes #164